### PR TITLE
add production build from sources option to build.gradle

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PROD_FLAG=false

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ logs/
 
 # Folder that has CTRE Phoenix Sim device config storage
 ctre_sim/
+
+lib/vendor/*
+lib/build/*

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ ctre_sim/
 
 lib/vendor/*
 lib/build/*
+lib/*
+lib

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# PWRUP Command Robot Base
+
+## Introduction
+
+Welcome to the **PWRUP Command Robot Base**! This repository serves as the foundation for building command-based robots that our team will create in the years ahead. By providing a structured framework, essential libraries, and key features, this template aims to streamline the development process and set our robots up for success.
+
+### Key Benefits:
+- **Modularity:** Easily fork this repository to kickstart a new robot project.
+- **Reusability:** Built-in features and libraries ensure consistency and speed up development.
+- **Scalability:** Designed to be expanded with additional functionality as our team's needs grow.
+
+---
+
+## Functionality
+
+This template provides the core structure for building robots using the **Command-Based Programming** model. It includes essential features and tools to simplify the creation and deployment of robot software, ensuring that our team has a solid base to work from.
+
+### Use Case:
+When a new robot project is started, the team can **fork** this repository, allowing them to focus on adding custom code specific to their robot, while benefiting from the standardized tools and libraries already included.
+
+---
+
+## Features Overview
+
+This repository includes several pre-configured features and libraries to accelerate development and promote best practices. As the team’s requirements evolve, we’ll continue to integrate more functionalities.
+
+### Current Features:
+
+1. **[Source vs. Online Library Building](./docs/SourceBuildingPlugin.md)**:
+   - Enables developers to decide whether to build the robot software from the **latest source code** or from a pre-built **online library**.
+   - This flexibility is particularly useful when working under tight deadlines or experimenting with local changes without needing to push to GitHub.
+   - See the detailed documentation [here](./docs/SourceBuildingPlugin.md).
+
+### Future Expansion:
+- Additional libraries and features will be added as the team's needs grow, ensuring the template evolves with the requirements of our robot projects.
+
+---
+
+## Getting Started
+
+### 1. Forking the Repository
+To create a new robot, simply **fork this repository** and start adding your custom robot code. The template is designed to be modular, allowing you to build upon it with minimal configuration.
+
+### 2. Using the Build System
+By default, the repository is configured to use Gradle, with a built-in option for selecting **source vs. online builds**. This ensures that whether you're pulling the latest version of a library from a repository or building locally, the process is seamless.
+
+Refer to the [SourceBuildingPlugin.md](./docs/SourceBuildingPlugin.md) for more information on configuring the build system based on your current needs.
+
+### 3. Customizing Your Robot Code
+Once you've forked the repository:
+- Add your custom subsystems, commands, and robot logic.
+- Leverage the pre-configured structure to ensure your robot code adheres to best practices and command-based programming principles.
+
+---
+
+## Contribution Guidelines
+
+If you have ideas for new features or improvements to this template, please feel free to:
+1. Fork the repository.
+2. Create a branch for your feature or fix.
+3. Submit a pull request with detailed information about the changes.
+
+We encourage all team members to contribute to this repository so that it continues to meet the evolving needs of our robot projects.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2024.3.2"
+    id "co.uzzu.dotenv.gradle" version "4.0.0" // Plugin for .env file support
 }
 
 java {
@@ -8,28 +9,25 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+repositories {
+    mavenCentral()
+    maven {
+        url 'https://jitpack.io'
+    }
+}
+
 def ROBOT_MAIN_CLASS = "frc.robot.Main"
 
-// Define my targets (RoboRIO) and artifacts (deployable files)
-// This is added by GradleRIO's backing project DeployUtils.
+// Define deploy target and artifacts
 deploy {
     targets {
         roborio(getTargetTypeClass('RoboRIO')) {
-            // Team number is loaded either from the .wpilib/wpilib_preferences.json
-            // or from command line. If not found an exception will be thrown.
-            // You can use getTeamOrDefault(team) instead of getTeamNumber if you
-            // want to store a team number in this file.
             team = project.frc.getTeamNumber()
             debug = project.frc.getDebugOrDefault(false)
 
             artifacts {
-                // First part is artifact name, 2nd is artifact type
-                // getTargetTypeClass is a shortcut to get the class type using a string
+                frcJava(getArtifactTypeClass('FRCJavaArtifact')) {}
 
-                frcJava(getArtifactTypeClass('FRCJavaArtifact')) {
-                }
-
-                // Static files artifact
                 frcStaticFileDeploy(getArtifactTypeClass('FileTreeArtifact')) {
                     files = project.fileTree('src/main/deploy')
                     directory = '/home/lvuser/deploy'
@@ -41,14 +39,45 @@ deploy {
 
 def deployArtifact = deploy.targets.roborio.artifacts.frcJava
 
-// Set to true to use debug for JNI.
 wpi.java.debugJni = false
 
-// Set this to true to enable desktop support.
 def includeDesktopSupport = false
 
-// Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
-// Also defines JUnit 5.
+// Helper function to convert a Jitpack dependency to GitHub repository URL
+String fromJitpackToGitHubRepository(String jitpackRepo) {
+    def parts = jitpackRepo.split(':')
+    def user = parts[0].replace("com.github.", "")
+    def repo = parts[1]
+    return "https://github.com/${user}/${repo}.git"
+}
+
+// Function to clone and build GitHub repositories using the Python script
+def addGithubRepo(String repo) {
+    def github = fromJitpackToGitHubRepository(repo)
+    def prodFlag = env.allVariables().get("PROD_FLAG") // Read PROD_FLAG from .env
+
+    if (prodFlag == "true") {
+        // Use the Python script to build the repository
+        println "Building ${github} using Python script..."
+        exec {
+            commandLine "python3", "scripts/clone_and_build_repos.py", "${github}"
+        }
+
+        // Add the built jar files as dependencies
+        fileTree(dir: "lib/build", include: '*.jar').each { jarFile ->
+            dependencies {
+                implementation files(jarFile)
+            }
+        }
+    } else {
+        // In non-PROD mode, add the repo as a regular Jitpack dependency
+        dependencies {
+            implementation repo
+        }
+    }
+}
+
+// Define project dependencies
 dependencies {
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
@@ -67,6 +96,8 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
+    // addGithubRepo("com.github.lolhol:KeybindConfigurator:0.2") // Example usage
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -76,13 +107,11 @@ test {
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
 }
 
-// Simulation configuration (e.g. environment variables).
+// Simulation settings
 wpi.sim.addGui().defaultEnabled = true
 wpi.sim.addDriverstation()
 
-// Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')
-// in order to make them all available at runtime. Also adding the manifest so WPILib
-// knows where to look for our Robot Class.
+// Create a fat jar (including all dependencies) and set the manifest for WPILib
 jar {
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     from sourceSets.main.allSource
@@ -90,12 +119,12 @@ jar {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
-// Configure jar and deploy tasks
+// Set the jar task for deployment
 deployArtifact.jarTask = jar
 wpi.java.configureExecutableTasks(jar)
 wpi.java.configureTestTasks(test)
 
-// Configure string concat to always inline compile
+// Configure the string concatenation setting for inline compilation
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+ext {
+    alreadyAdded = []
+}
+
 repositories {
     mavenCentral()
     maven {
@@ -43,39 +47,7 @@ wpi.java.debugJni = false
 
 def includeDesktopSupport = false
 
-// Helper function to convert a Jitpack dependency to GitHub repository URL
-String fromJitpackToGitHubRepository(String jitpackRepo) {
-    def parts = jitpackRepo.split(':')
-    def user = parts[0].replace("com.github.", "")
-    def repo = parts[1]
-    return "https://github.com/${user}/${repo}.git"
-}
-
-// Function to clone and build GitHub repositories using the Python script
-def addGithubRepo(String repo) {
-    def github = fromJitpackToGitHubRepository(repo)
-    def prodFlag = env.allVariables().get("PROD_FLAG") // Read PROD_FLAG from .env
-
-    if (prodFlag == "true") {
-        // Use the Python script to build the repository
-        println "Building ${github} using Python script..."
-        exec {
-            commandLine "python3", "scripts/clone_and_build_repos.py", "${github}"
-        }
-
-        // Add the built jar files as dependencies
-        fileTree(dir: "lib/build", include: '*.jar').each { jarFile ->
-            dependencies {
-                implementation files(jarFile)
-            }
-        }
-    } else {
-        // In non-PROD mode, add the repo as a regular Jitpack dependency
-        dependencies {
-            implementation repo
-        }
-    }
-}
+// addGithubRepo('lolhol', 'KeybindConfigurator', '0.2', true)
 
 // Define project dependencies
 dependencies {
@@ -96,7 +68,8 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-    // addGithubRepo("com.github.lolhol:KeybindConfigurator:0.2") // Example usage
+    addGithubRepoJitPack("lolhol", "KeybindConfigurator", "0.2") // Example usage
+
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -127,4 +100,64 @@ wpi.java.configureTestTasks(test)
 // Configure the string concatenation setting for inline compilation
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+}
+
+// ---------------- Helper functions ----------------
+
+String toJitpack(String user, String repo) {
+    return toJitpack(user, repo, "main-SNAPSHOT")
+}
+
+String toJitpack(String user, String repo, String version) {
+    return "com.github.${user}:${repo}:${version}"
+}
+
+String toGithub(String user, String repo) {
+    return "https://github.com/${user}/${repo}.git"
+}
+
+def addGithubRepoJitPack(String user, String repo, String version) {
+    addGithubRepo(user, repo, "com.github.${user}:${repo}:${version}")
+}
+
+def addGithubRepo(String user, String repo, String nonProductionImplementationString) {
+    addGithubRepo(user, repo, nonProductionImplementationString, env.allVariables().get("PROD_FLAG") == "true")
+}
+
+def addGithubRepo(String user, String repo, String nonProductionImplementationString, boolean isProduction) {
+    if (isProduction) {
+        println("")
+        println("Building ${user}/${repo}")
+        println("")
+        def output = new ByteArrayOutputStream()
+        exec {
+            commandLine "python3", "scripts/clone_and_build_repos.py", toGithub(user, repo)
+            standardOutput = output
+        }
+
+        def brightYellow = '\u001B[93m'
+
+        def reset = '\u001B[0m'
+
+        println("${brightYellow}${output.toString()}${reset}")
+        println("")
+        println("")
+        println("")
+
+        def jarFiles = fileTree(dir: "lib/build", include: '*.jar').filter { jarFile ->
+            !alreadyAdded.contains(jarFile)
+        }
+
+        dependencies {
+            implementation files(jarFiles)
+        }
+
+        alreadyAdded.addAll(jarFiles)
+
+        return;
+    }
+
+    dependencies {
+        implementation nonProductionImplementationString
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,6 @@ wpi.java.debugJni = false
 
 def includeDesktopSupport = false
 
-// addGithubRepo('lolhol', 'KeybindConfigurator', '0.2', true)
-
 // Define project dependencies
 dependencies {
     implementation wpi.java.deps.wpilib()
@@ -68,7 +66,7 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-    addGithubRepoJitPack("lolhol", "KeybindConfigurator", "0.2") // Example usage
+    // addGithubRepoJitPack("lolhol", "KeybindConfigurator", "0.2") // Example usage
 
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'

--- a/docs/SourceBuildingPlugin.md
+++ b/docs/SourceBuildingPlugin.md
@@ -1,0 +1,63 @@
+# Build from Source vs. from Online Library
+
+## Purpose
+
+When you're in a situation where you don't have time to re-publish a library, you can enable a flag that builds the robot code from the latest commit or local version of the library rather than the online repository. This allows you to modify the library's code **locally** without needing to push it to GitHub. This process is streamlined by using [JitPack](https://jitpack.io) for building the library. **Note**: Do not use this process without JitPack.
+
+## Methodology
+
+1. The `.env` file includes a `PROD_FLAG` that can be set to either `"true"` or `"false"`. The default value is `"false"`.
+2. The `gradlew.bat` script will:
+    - Build the library from the latest published version if the `PROD_FLAG` is `"false"`.
+    - Build the library from the source code (latest commit or local changes) if the `PROD_FLAG` is `"true"`.
+
+```mermaid
+graph LR;
+A(Build) --> B(Download Dependencies) --> C{Is PROD_FLAG true?}
+C --> |true| D(Create folders lib, lib/vendor, lib/build)
+D --> E(Download latest commit from GitHub)
+E --> G(Build from source using `./gradlew build`)
+G --> H(Copy JAR files to lib/build and implement them as dependencies)
+C --> |false| F(Implement from online repository)
+F --> I(Compile robot code)
+H --> I
+```
+
+### `PROD_FLAG` Behavior:
+- **PROD_FLAG = "false"**: The script pulls the dependency from the **online repository** using JitPack or specified default implementation string.
+- **PROD_FLAG = "true"**: The script clones the repository from GitHub and builds the dependency from the **latest commit or local changes**.
+
+## Usage
+
+In your `build.gradle` file, you can manage dependencies based on the `PROD_FLAG` environment variable:
+
+### Example Code:
+```java
+dependencies {
+
+    // Add other dependencies here
+    
+    // Use addGithubRepo for dynamic GitHub dependencies
+    addGithubRepoJitPack("__USER__", "__REPO__", "__VERSION__")
+    // Example: addGithubRepoJitPack("lolhol", "KeybindConfigurator", "0.2")
+
+    // For testing
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+```
+
+## How It Works:
+
+- If you are in **non-production mode** (`PROD_FLAG = "false"`):
+    - The script pulls the dependency from JitPack using the format: `com.github.__user__:__repo__:__version__`.
+
+- If you are in **production mode** (`PROD_FLAG = "true"`):
+    - The script clones the GitHub repository, builds the project, and automatically adds the built `.jar` files as dependencies in the project.
+
+### Steps in Production Mode:
+
+1. Clone the GitHub repository locally.
+2. Build the project using Gradle's `./gradlew build` command.
+3. Copy the resulting `.jar` files to the `lib/build` directory.
+4. Add the `.jar` files as dependencies to the project.

--- a/scripts/clone_and_build_repos.py
+++ b/scripts/clone_and_build_repos.py
@@ -1,0 +1,55 @@
+import sys
+import os
+import subprocess
+import shutil
+import glob
+
+def main():
+    if len(sys.argv) <= 1:
+        print("No Github libs found! Exiting...")
+        exit(0)
+
+    base_dir = os.getcwd()
+    lib_dir = os.path.join(base_dir, "lib")
+    vendor_dir = os.path.join(lib_dir, "vendor")
+    build_dir = os.path.join(lib_dir, "build")
+
+    os.makedirs(lib_dir, exist_ok=True)
+    os.makedirs(vendor_dir, exist_ok=True)
+    os.makedirs(build_dir, exist_ok=True)
+
+    for lib in sys.argv[1:]:
+        print("Cloning " + lib)
+
+        os.chdir(lib_dir)
+        os.chdir(vendor_dir)
+
+        name = lib.split("/")[-1].replace(".git", "")
+        print(f"Repository name: {name}")
+
+        if not name in os.listdir("."):
+            subprocess.run(["git", "clone", lib])
+
+            os.chdir(name)
+            subprocess.run(["git", "checkout", "master"])
+            subprocess.run(["git", "pull"])
+        else:
+            os.chdir(name)
+
+        if "build.gradle" in os.listdir("."):
+            subprocess.run(["./gradlew", "clean"])
+            subprocess.run(["./gradlew", "build"])
+
+            jar_files = glob.glob("build/libs/*.jar")
+            if jar_files:
+                for jar_file in jar_files:
+                    shutil.copy(jar_file, os.path.join(base_dir, "lib/build"))
+                    print(f"Copied {jar_file} to {os.path.join(base_dir, 'lib/build')}")
+            else:
+                print("No .jar files found in build/libs!")
+        else:
+            print(f"No build.gradle found in {name}. Skipping this repository!")
+
+if __name__ == "__main__":
+    main()
+    exit(0)

--- a/src/main/java/frc/robot/Main.java
+++ b/src/main/java/frc/robot/Main.java
@@ -7,17 +7,21 @@ package frc.robot;
 import edu.wpi.first.wpilibj.RobotBase;
 
 /**
- * Do NOT add any static variables to this class, or any initialization at all. Unless you know what
- * you are doing, do not modify this file except to change the parameter class to the startRobot
+ * Do NOT add any static variables to this class, or any initialization at all.
+ * Unless you know what
+ * you are doing, do not modify this file except to change the parameter class
+ * to the startRobot
  * call.
  */
 public final class Main {
-  private Main() {}
+  private Main() {
+  }
 
   /**
    * Main initialization function. Do not perform any initialization here.
    *
-   * <p>If you change your main robot class, change the parameter type.
+   * <p>
+   * If you change your main robot class, change the parameter type.
    */
   public static void main(String... args) {
     RobotBase.startRobot(Robot::new);


### PR DESCRIPTION
This allows us to much more easily debug and re-code our libraries without having to re-pull and push them from your main computer every time. 

**What this does**
When PROD mode is enabled, builds libraries localy (clone from github, ./gradlew build, copy into lib/build, add to dependencies) when PROD_FLAG is set to true in the .env file. Everything will compile as normal, except that the libraries used in dependencies will be built localy from the LOCAL code.

When PROD mode is DISABLED, builds from [jitpack](https://jitpack.io/) (package repository for git).

**NOTE: THE CODE DOES NOT CLONE AGAIN IF THE LIBRARY IS ALREADY THERE SO CHANGES ARE BEING ACCOUNTED FOR**

**Why is this good**
During competitions we might not have time to modify library code, build it, upload it to remote, publish... etc. However, now this allows us to modify the local library code and fix it later using the changes that are tracked in the local git of that library.

This is essentially why many linux users use a linux that builds everything localy - to be able to change some code very quickly and re-build. 

- **USE NOW, FIX LATER**

**Changes**
- made python script to clone / build the libraries into their designated folders
- modified build.gradle to run the python script whenever dependencies are indexed (every build)
- added .env where you can set the production flag that defines if you should compile from online source or from local source 